### PR TITLE
feat: add prepare script for git URL installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "node": ">=20.0.0"
   },
   "scripts": {
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build && npm test",
-    "prepack": "npm run build",
     "test:e2e": "npm run build && npm run test:e2e:stdio && npm run test:e2e:sse && npm run test:e2e:youtube",
     "test:e2e:stdio": "node tests/e2e/e2e_stdio_mcp_client_test.mjs",
     "test:e2e:sse": "./scripts/run-sse-test.sh",


### PR DESCRIPTION
## Summary

- Replace `prepack` with `prepare` in package.json scripts
- Enables `npx -y github:user/repo` and `npm install github:user/repo` to work

## Problem

When installing from a git URL, npm runs the [`prepare` lifecycle script](https://docs.npmjs.com/cli/v10/using-npm/scripts#life-cycle-scripts) to build from source. The package currently has `prepack` and `prepublishOnly` but no `prepare`, so TypeScript is never compiled and `dist/server.js` doesn't exist. This causes the bin entry to fail with "command not found".

## Change

- **Added** `prepare: "npm run build"` — runs `tsc` on git installs, local `npm install`, and before `npm pack`/`npm publish`
- **Removed** `prepack: "npm run build"` — redundant since `prepare` runs before `prepack` in the lifecycle

## Impact on npm publish

No change. The publish lifecycle is:
1. `prepublishOnly` → `npm run build && npm test` (unchanged)
2. `prepare` → `npm run build` (new, replaces prepack timing)

## Test plan

- [ ] `npx -y github:zoharbabin/google-research-mcp` starts the server
- [ ] `npm publish --dry-run` succeeds
- [ ] `npm install` from clean clone builds `dist/`