### PR TITLE
fix: add cheerio as explicit dependency (resolves #94)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@danielxceron/youtube-transcript": "^1.2.6",
         "@modelcontextprotocol/sdk": "^1.26.0",
+        "cheerio": "1.0.0-rc.12",
         "cors": "^2.8.5",
         "crawlee": "^3.13.2",
         "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
   "dependencies": {
     "@danielxceron/youtube-transcript": "^1.2.6",
     "@modelcontextprotocol/sdk": "^1.26.0",
+    "cheerio": "1.0.0-rc.12",
     "cors": "^2.8.5",
     "crawlee": "^3.13.2",
     "express": "^5.1.0",


### PR DESCRIPTION
## Summary
- `cheerio` is directly imported in `src/shared/citationExtractor.ts` but was not listed in `package.json`
- It only resolved as a transitive dependency of `crawlee`, which is fragile and breaks in stricter environments (pnpm, `npx` from git URL)
- Pins to `1.0.0-rc.12` to match crawlee's exact version, avoiding the duplicate installation that PR #94's `^1.0.0` (→ 1.2.0) would create

## Changes
- **+1 line** in `package.json` (adds `"cheerio": "1.0.0-rc.12"`)
- **+1 line** in `package-lock.json` (registers the direct dependency)
- Zero duplication — cheerio remains deduped across the entire dependency tree

## Comparison with PR #94
| | PR #94 | This PR |
|---|---|---|
| Version | `^1.0.0` → resolves to 1.2.0 | `1.0.0-rc.12` (exact crawlee match) |
| Lockfile changes | +304 lines (duplicate cheerio tree) | +1 line (no duplication) |
| Cheerio copies | 2 (1.2.0 + nested 1.0.0-rc.12) | 1 (shared 1.0.0-rc.12) |

## Credit
Based on the issue identified by @jimweller in #94.

## Test plan
- [x] All 828 unit tests pass
- [x] All 26 citation extractor tests pass
- [x] `npm ls cheerio` shows single deduped version
- [x] `npm audit` — 0 vulnerabilities
- [x] Build passes on Node 24
- [x] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)