### PR TITLE
fix: remove PID lock that kills concurrent healthy instances

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Memory Optimization — Lazy PlaywrightCrawler**: `PlaywrightCrawler` is now dynamically imported on first JS-rendered scrape instead of at startup — saves ~30-50 MB for sessions that never need JS rendering
 - **Memory Optimization — Lazy Document Parsers**: pdf-parse, mammoth, and jszip are now dynamically imported inside their respective parse functions instead of at module load — saves ~74 MB RSS
 - **Memory Optimization — Lazy HTTP Dependencies**: express, cors, and express-rate-limit are now dynamically imported inside `createAppAndHttpTransport()` — saves ~24 MB in STDIO mode
-- **PID Lock File**: Server now writes a PID lock file (`storage/.server.pid`) on startup and sends SIGTERM to stale processes, preventing orphan instance accumulation across MCP client reconnections
 - **Stdin Health Check**: Periodic check (every 5s) detects destroyed or ended stdin as a safety net for parent process death beyond the existing `end`/`close` event listeners
 - **Bounded sanitizeUrlCache**: URL sanitization cache is now capped at 500 entries with FIFO eviction to prevent unbounded memory growth over long sessions
 - **Event Store Lazy Loading**: Event store `eagerLoading` set to `false` — events are loaded on demand instead of all at startup, reducing memory for STDIO sessions that don't use HTTP reconnection

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -351,10 +351,9 @@ The server uses a **single unified shutdown handler** that responds to `SIGINT`,
 4. Exits the process.
 
 ### Orphan Process Prevention
-Multiple layers prevent orphaned processes from accumulating:
-1. **PID lock file** (`storage/.server.pid`): On startup, the server checks for a stale PID lock and sends SIGTERM to any orphaned instance before writing its own PID. The lock is cleaned up on graceful shutdown.
-2. **Stdin EOF detection**: When the parent process (Claude Code, Claude Desktop) terminates, the server detects stdin `end`/`close` events and triggers graceful shutdown.
-3. **Stdin health check**: A periodic check (every 5s) detects destroyed or ended stdin as a safety net for cases where the parent dies without cleanly closing the pipe.
+Two layers prevent orphaned processes from accumulating:
+1. **Stdin EOF detection**: When the parent process (Claude Code, Claude Desktop) terminates, the server detects stdin `end`/`close` events and triggers graceful shutdown.
+2. **Stdin health check**: A periodic check (every 5s) detects destroyed or ended stdin as a safety net for cases where the parent dies without cleanly closing the pipe.
 
 ### Startup Cleanup
 On initialization, the server sweeps the crawlee storage directory for orphaned temp directories (`cheerio_*`, `playwright_*`) left by previous crashes.

--- a/src/server.ts
+++ b/src/server.ts
@@ -251,41 +251,6 @@ const PKG_VERSION: string = (() => {
 const DEFAULT_CACHE_PATH = path.resolve(PROJECT_ROOT, 'storage', 'persistent_cache');
 const DEFAULT_EVENT_PATH = path.resolve(PROJECT_ROOT, 'storage', 'event_store');
 const DEFAULT_CRAWLEE_STORAGE_PATH = path.resolve(PROJECT_ROOT, 'storage', 'crawlee');
-const PID_LOCK_PATH = path.resolve(PROJECT_ROOT, 'storage', '.server.pid');
-
-// --- PID Lock (prevents orphan instance accumulation) ---
-async function acquirePidLock(): Promise<void> {
-  try {
-    await fs.mkdir(path.dirname(PID_LOCK_PATH), { recursive: true });
-    const existing = await fs.readFile(PID_LOCK_PATH, 'utf8').catch(() => null);
-    if (existing) {
-      const pid = parseInt(existing.trim(), 10);
-      if (!isNaN(pid) && pid !== process.pid) {
-        try {
-          process.kill(pid, 0); // check if alive
-          process.kill(pid, 'SIGTERM');
-          logger.info(`Sent SIGTERM to orphaned server process ${pid}`);
-          await new Promise(r => setTimeout(r, 1500));
-        } catch {
-          // process already dead — stale lock
-        }
-      }
-    }
-    await fs.writeFile(PID_LOCK_PATH, String(process.pid), 'utf8');
-  } catch (error) {
-    logger.warn('Failed to acquire PID lock', { error: String(error) });
-  }
-}
-
-async function releasePidLock(): Promise<void> {
-  try {
-    const content = await fs.readFile(PID_LOCK_PATH, 'utf8').catch(() => '');
-    if (content.trim() === String(process.pid)) {
-      await fs.unlink(PID_LOCK_PATH);
-    }
-  } catch { /* best-effort */ }
-}
-
 // --- Global Instances ---
 // Initialize Cache and Event Store globally so they are available for both transports
 let globalCacheInstance: PersistentCache;
@@ -2750,7 +2715,6 @@ async function gracefulShutdown(signal: string) {
     }
     if (globalCacheInstance?.dispose) await globalCacheInstance.dispose();
     if (eventStoreInstance?.dispose) await eventStoreInstance.dispose();
-    await releasePidLock();
   } catch (error) {
     logger.error('Error during shutdown', { error: String(error) });
   }
@@ -2768,11 +2732,6 @@ process.stdin.on('close', () => gracefulShutdown('stdin-close'));
  * based on execution context (direct run vs. import) and environment variables.
  */
 (async () => {
-  // Prevent orphan instance accumulation: kill any stale server process
-  if (!process.env.JEST_WORKER_ID) {
-    await acquirePidLock();
-  }
-
   // Initialize global instances (cache, event store, etc.).
   // Defer the expensive eager-load of the persistent cache so the STDIO
   // transport can be established first — the MCP client needs a responsive


### PR DESCRIPTION
## Summary

- Removes the PID lock mechanism (`acquirePidLock`/`releasePidLock`) added in v6.2.0 that assumes single-instance-per-install
- When multiple STDIO clients (e.g. Claude Code) spawn concurrent instances, they share the same npx cache directory and PID file, causing the newer instance to SIGTERM healthy peers
- Orphan detection is already covered by stdin EOF listeners and the 5-second `stdinHealthCheck` interval; for HTTP mode, `EADDRINUSE` prevents port conflicts
- Updates CHANGELOG and architecture docs to reflect the removal

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (860/860)
- [ ] Verify concurrent STDIO instances coexist without killing each other
- [ ] Verify orphaned instances still shut down via stdin pipe closure

Fixes #104